### PR TITLE
[3/3] Settings: Disable ADB over network on disconnect

### DIFF
--- a/res/values/custom_strings.xml
+++ b/res/values/custom_strings.xml
@@ -58,6 +58,8 @@
     <string name="adb_over_network_summary">Enable TCP/IP debugging over network interfaces (Wi-Fi, USB networks). This setting is reset on reboot</string>
     <!-- Warning for Adb over Network -->
     <string name="adb_over_network_warning">WARNING: When ADB over network is enabled, your phone is open for intrusions on all connected networks, including GSM data network!\n\nOnly use this feature when you are connected on trusted networks.\n\nDo you really want to enable this function?</string>
+    <string name="adb_over_network_disable_on_disconnect_title">Disable ADB over network on disconnect</string>
+    <string name="adb_over_network_disable_on_disconnect_summary">ADB over network will be disabled when disconnecting from Wi-Fi</string>
 
     <!-- Display : Rotation -->
     <string name="display_rotation_title">Rotation</string>

--- a/res/xml/development_prefs.xml
+++ b/res/xml/development_prefs.xml
@@ -122,6 +122,13 @@
             android:summary="@string/adb_over_network_summary"
             android:dependency="enable_adb"/>
 
+        <org.omnirom.omnigears.preference.SystemSettingSwitchPreference
+            android:key="disable_adb_network_on_disconnect"
+            android:title="@string/adb_over_network_disable_on_disconnect_title"
+            android:summary="@string/adb_over_network_disable_on_disconnect_summary"
+            android:dependency="adb_over_network"
+            android:defaultValue="true" />
+
         <SwitchPreference
             android:key="bugreport_in_power"
             android:title="@string/bugreport_in_power"


### PR DESCRIPTION
ADB over network is not disabled before the next reboot, which creates
a potential security threat when this setting is left enabled and the
device gets re-connected to public wifi networks.

To mitigate that risk, introduce a new switch to disable ADB over network
as soon as the device gets disconnected from wifi.

Change-Id: Ib2312178d7d844e8f98c9164d00126572393f269